### PR TITLE
fix: fix wasm path, fix tmp_vkey, tmp_zkey path

### DIFF
--- a/crates/cli/src/convert_zkey.rs
+++ b/crates/cli/src/convert_zkey.rs
@@ -3,29 +3,41 @@ use ark_circom::read_zkey;
 use ark_groth16::Groth16;
 use ark_serialize::CanonicalSerialize;
 use ark_snark::SNARK;
+use color_eyre::eyre::Result;
 use std::path::Path;
 use std::path::PathBuf;
-use color_eyre::eyre::Result;
 
 type GrothBn = Groth16<Bn254>;
 
-pub fn convert_zkey(input_zkey: &Path) -> Result<((std::fs::File, PathBuf), (std::fs::File, PathBuf))> {
+pub fn convert_zkey(
+    input_zkey: &Path,
+) -> Result<((std::fs::File, PathBuf), (std::fs::File, PathBuf))> {
     let mut zkey_file = std::fs::File::open(input_zkey).unwrap();
     let (params, _matrices) = read_zkey(&mut zkey_file).unwrap();
 
-    let input_name = input_zkey.file_name().and_then(|n| n.to_str()).unwrap_or("circuit");
-    let input_name = input_name
-        .to_lowercase();
-    let input_name = input_name
-        .strip_suffix(".zkey")
+    let input_name = input_zkey
+        .file_name()
+        .and_then(|n| n.to_str())
         .unwrap_or("circuit");
-    let temp_zkey = std::env::temp_dir().join(format!("{}_temp.zkey", input_name)).canonicalize()?;
+    let input_name = input_name.to_lowercase();
+    let input_name = input_name.strip_suffix(".zkey").unwrap_or("circuit");
+    let temp_zkey = std::env::temp_dir().join(format!("{}_temp.zkey", input_name));
+
+    if !temp_zkey.exists() {
+        std::fs::File::create(&temp_zkey).unwrap(); // Create the file if it doesn't exist
+    }
+    temp_zkey.canonicalize()?;
     let mut writer = std::fs::File::create(&temp_zkey).unwrap();
     params.serialize_uncompressed(&mut writer).unwrap();
 
     let pvk = GrothBn::process_vk(&params.vk).unwrap();
 
-    let temp_vkey = std::env::temp_dir().join(format!("{}_temp.vkey", input_name)).canonicalize()?;
+    let temp_vkey = std::env::temp_dir().join(format!("{}_temp.vkey", input_name));
+
+    if !temp_vkey.exists() {
+        std::fs::File::create(&temp_vkey).unwrap(); // Create the file if it doesn't exist
+    }
+    temp_vkey.canonicalize()?;
     let mut vkey_writer = std::fs::File::create(&temp_vkey).unwrap();
     pvk.serialize_uncompressed(&mut vkey_writer).unwrap();
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -53,6 +53,7 @@ fn main() -> Result<()> {
     let wasm_src = Path::new(manifest_dir).join("../wasm/src/circuit.rs").canonicalize().unwrap();
 
     let r1cs_path = Path::new(&cli.r1cs).canonicalize().unwrap();
+    let wasm_path = Path::new(&cli.wasm).canonicalize().unwrap();
 
     let mut output = std::fs::File::create(&wasm_src)?;
 
@@ -68,7 +69,7 @@ const WASM: &[u8] = include_bytes!("{}");
 pub fn prove(inputs: &str) -> String {{
     prove_inner(inputs, ZKEY, R1CS, WASM)
 }}
-"#, zkey_path.display(), r1cs_path.display(), wasm_src.display());
+"#, zkey_path.display(), r1cs_path.display(), wasm_path.display());
 
     output.write_all(code.as_bytes())?;
 


### PR DESCRIPTION
- fix `wasm_path`
  - `wasm_path` is the file path, `wasm_src` is the `wasm.rs` file
- fix `tmp_vkey` and `tmp_zkey`
  - If it does not exists, it throws the error